### PR TITLE
Feat: add ack watchdog timeout to detect packet sent that expects a response

### DIFF
--- a/client.go
+++ b/client.go
@@ -1382,12 +1382,14 @@ func (c *client) pingRespReceived() {
 
 // checkAndSetFastReconnectCheckStartTime will be called whenever a packet is sent to check the broker's connection status
 func (c *client) checkAndSetFastReconnectCheckStartTime() {
-	fastReconnectTime := c.fastReconnectCheckStartTime.Load().(time.Time)
-	lastReceivedTime := c.lastReceived.Load().(time.Time)
+	if c.options.AckTimeout > 0 {
+		fastReconnectTime := c.fastReconnectCheckStartTime.Load().(time.Time)
+		lastReceivedTime := c.lastReceived.Load().(time.Time)
 
-	if !fastReconnectTime.After(lastReceivedTime) {
-		c.fastReconnectCheckStartTime.Store(time.Now())
-		DEBUG.Println(CLI, "fastReconnectCheckStartTime set", c.fastReconnectCheckStartTime.Load().(time.Time).String())
-		c.logger.Debug("fastReconnectCheckStartTime set", slog.String("time", c.fastReconnectCheckStartTime.Load().(time.Time).String()), componentAttr(CLI))
+		if !fastReconnectTime.After(lastReceivedTime) {
+			c.fastReconnectCheckStartTime.Store(time.Now())
+			ERROR.Println(CLI, "fastReconnectCheckStartTime set", c.fastReconnectCheckStartTime.Load().(time.Time).String())
+			c.logger.Error("fastReconnectCheckStartTime set", slog.String("time", c.fastReconnectCheckStartTime.Load().(time.Time).String()), componentAttr(CLI))
+		}
 	}
 }

--- a/client.go
+++ b/client.go
@@ -891,10 +891,6 @@ func (c *client) Publish(topic string, qos byte, retained bool, payload interfac
 		DEBUG.Println(CLI, "sending publish message, topic:", topic)
 		c.logger.Debug("sending publish message", slog.String("topic", topic), componentAttr(CLI))
 
-		if pub.Qos > 0 {
-			c.checkAndSetFastReconnectCheckStartTime()
-		}
-
 		publishWaitTimeout := c.options.WriteTimeout
 		if publishWaitTimeout == 0 {
 			publishWaitTimeout = time.Second * 30
@@ -995,7 +991,6 @@ func (c *client) Subscribe(topic string, qos byte, callback MessageHandler) Toke
 		}
 		select {
 		case c.oboundP <- &PacketAndToken{p: sub, t: token}:
-			c.checkAndSetFastReconnectCheckStartTime()
 		case <-time.After(subscribeWaitTimeout):
 			token.setError(errors.New("subscribe was broken by timeout"))
 		}
@@ -1078,7 +1073,6 @@ func (c *client) SubscribeMultiple(filters map[string]byte, callback MessageHand
 		}
 		select {
 		case c.oboundP <- &PacketAndToken{p: sub, t: token}:
-			c.checkAndSetFastReconnectCheckStartTime()
 		case <-time.After(subscribeWaitTimeout):
 			token.setError(errors.New("subscribe was broken by timeout"))
 		}
@@ -1325,7 +1319,6 @@ func (c *client) Unsubscribe(topics ...string) Token {
 		}
 		select {
 		case c.oboundP <- &PacketAndToken{p: unsub, t: token}:
-			c.checkAndSetFastReconnectCheckStartTime()
 			for _, topic := range topics {
 				c.msgRouter.deleteRoute(topic)
 			}

--- a/client.go
+++ b/client.go
@@ -663,10 +663,14 @@ func (c *client) startCommsWorkers(conn net.Conn, connectionUp connCompletedFn, 
 	c.conn = conn // Store the connection
 
 	c.stop = make(chan struct{})
-	if c.options.KeepAlive != 0 {
-		atomic.StoreInt32(&c.pingOutstanding, 0)
+
+	if c.options.KeepAlive != 0 || c.options.AckTimeout != 0 {
 		c.lastReceived.Store(time.Now())
 		c.lastSent.Store(time.Now())
+	}
+
+	if c.options.KeepAlive != 0 {
+		atomic.StoreInt32(&c.pingOutstanding, 0)
 		c.workers.Add(1)
 		go keepalive(c, conn)
 	}

--- a/client.go
+++ b/client.go
@@ -1389,16 +1389,8 @@ func (c *client) pingRespReceived() {
 
 // checkAndSetFastReconnectCheckStartTime will be called whenever a packet is sent to check the broker's connection status
 func (c *client) checkAndSetFastReconnectCheckStartTime() {
-	fastReconnect := c.fastReconnectCheckStartTime.Load()
-	lastReceived := c.lastReceived.Load()
-
-	var fastReconnectTime, lastReceivedTime time.Time
-	if fastReconnect != nil {
-		fastReconnectTime = fastReconnect.(time.Time)
-	}
-	if lastReceived != nil {
-		lastReceivedTime = lastReceived.(time.Time)
-	}
+	fastReconnectTime := c.fastReconnectCheckStartTime.Load().(time.Time)
+	lastReceivedTime := c.lastReceived.Load().(time.Time)
 
 	if !fastReconnectTime.After(lastReceivedTime) {
 		c.fastReconnectCheckStartTime.Store(time.Now())

--- a/net.go
+++ b/net.go
@@ -356,6 +356,10 @@ func startOutgoingComms(conn net.Conn,
 					}
 				}
 
+				if msg.Qos > 0 {
+					c.checkAndSetFastReconnectCheckStartTime()
+				}
+
 				if msg.Qos == 0 {
 					pub.t.flowComplete()
 				}
@@ -378,6 +382,11 @@ func startOutgoingComms(conn net.Conn,
 					continue
 				}
 
+				switch msg.p.(type) {
+				case *packets.SubscribePacket, *packets.UnsubscribePacket:
+					c.checkAndSetFastReconnectCheckStartTime()
+				}
+
 				if _, ok := msg.p.(*packets.DisconnectPacket); ok {
 					msg.t.(*DisconnectToken).flowComplete()
 					DEBUG.Println(NET, "outbound wrote disconnect, closing connection")
@@ -394,11 +403,6 @@ func startOutgoingComms(conn net.Conn,
 				DEBUG.Println(NET, "obound from incoming msg to write, type", reflect.TypeOf(msg.p), " ID ", msg.p.Details().MessageID)
 				logger.Debug("obound from incoming msg to write", slog.String("type", reflect.TypeOf(msg.p).String()), slog.Uint64("messageID", uint64(msg.p.Details().MessageID)), componentAttr(NET))
 
-				switch msg.p.(type) {
-				case *packets.PubrelPacket:
-					c.checkAndSetFastReconnectCheckStartTime()
-				}
-
 				if err := msg.p.Write(conn); err != nil {
 					ERROR.Println(NET, "outgoing oboundFromIncoming reporting error", err)
 					logger.Error("outgoing oboundFromIncoming reporting error", slog.String("error", err.Error()), componentAttr(NET))
@@ -407,6 +411,11 @@ func startOutgoingComms(conn net.Conn,
 					}
 					errChan <- err
 					continue
+				}
+
+				switch msg.p.(type) {
+				case *packets.PubrelPacket:
+					c.checkAndSetFastReconnectCheckStartTime()
 				}
 			}
 			c.UpdateLastSent() // Record that a packet has been received (for keepalive routine)

--- a/net.go
+++ b/net.go
@@ -393,6 +393,12 @@ func startOutgoingComms(conn net.Conn,
 				}
 				DEBUG.Println(NET, "obound from incoming msg to write, type", reflect.TypeOf(msg.p), " ID ", msg.p.Details().MessageID)
 				logger.Debug("obound from incoming msg to write", slog.String("type", reflect.TypeOf(msg.p).String()), slog.Uint64("messageID", uint64(msg.p.Details().MessageID)), componentAttr(NET))
+
+				switch msg.p.(type) {
+				case *packets.PubrelPacket:
+					c.checkAndSetFastReconnectCheckStartTime()
+				}
+
 				if err := msg.p.Write(conn); err != nil {
 					ERROR.Println(NET, "outgoing oboundFromIncoming reporting error", err)
 					logger.Error("outgoing oboundFromIncoming reporting error", slog.String("error", err.Error()), componentAttr(NET))
@@ -419,6 +425,7 @@ type commsFns interface {
 	persistOutbound(m packets.ControlPacket) // add the packet to the outbound store
 	persistInbound(m packets.ControlPacket)  // add the packet to the inbound store
 	pingRespReceived()                       // Called when a ping response is received
+	checkAndSetFastReconnectCheckStartTime() // Called when a packet that expects a response is sent
 }
 
 // startComms initiates goroutines that handles communications over the network connection

--- a/options.go
+++ b/options.go
@@ -153,7 +153,7 @@ func NewClientOptions() *ClientOptions {
 		CustomOpenConnectionFn:  nil,
 		AutoAckDisabled:         false,
 		LogVerbosity:            LogLevelDefault,
-		AckTimeout:              5 * time.Second,
+		AckTimeout:              0,
 	}
 	return o
 }

--- a/options.go
+++ b/options.go
@@ -106,6 +106,7 @@ type ClientOptions struct {
 	CustomOpenConnectionFn  OpenConnectionFunc
 	AutoAckDisabled         bool
 	LogVerbosity            LogLevel
+	AckTimeout              time.Duration
 }
 
 // NewClientOptions will create a new ClientClientOptions type with some
@@ -152,6 +153,7 @@ func NewClientOptions() *ClientOptions {
 		CustomOpenConnectionFn:  nil,
 		AutoAckDisabled:         false,
 		LogVerbosity:            LogLevelDefault,
+		AckTimeout:              5 * time.Second,
 	}
 	return o
 }
@@ -463,5 +465,10 @@ func (o *ClientOptions) SetAutoAckDisabled(autoAckDisabled bool) *ClientOptions 
 // SetLogLevel sets the log level for the client. This will be used to control the verbosity of the logs
 func (o *ClientOptions) SetLogLevel(logVerbosity LogLevel) *ClientOptions {
 	o.LogVerbosity = logVerbosity
+	return o
+}
+
+func (o *ClientOptions) SetAckTimeout(ackTimeout time.Duration) *ClientOptions {
+	o.AckTimeout = ackTimeout
 	return o
 }

--- a/ping.go
+++ b/ping.go
@@ -63,6 +63,7 @@ func keepalive(c *client, conn io.Writer) {
 					DEBUG.Println(PNG, "keepalive sending ping")
 					c.logger.Debug("keepalive sending ping", componentAttr(PNG))
 					ping := packets.NewControlPacket(packets.Pingreq).(*packets.PingreqPacket)
+					c.checkAndSetFastReconnectCheckStartTime()
 					// We don't want to wait behind large messages being sent, the `Write` call
 					// will block until it is able to send the packet.
 					atomic.StoreInt32(&c.pingOutstanding, 1)

--- a/watchdog.go
+++ b/watchdog.go
@@ -1,0 +1,39 @@
+package mqtt
+
+import (
+	"errors"
+	"time"
+)
+
+// ackWatchdog monitors the packet sent to the broker that expects a response
+// triggers a reconnection if no response is received within the timeout period.
+func ackWatchdog(c *client, ackTimeout time.Duration) {
+	defer c.workers.Done()
+
+	ticker := time.NewTicker(ackTimeout / 2)
+	defer ticker.Stop()
+
+	DEBUG.Println(NET, "ack watchdog started")
+	c.logger.Debug("ack watchdog started", componentAttr(NET))
+
+	for {
+		select {
+		case <-c.stop:
+			DEBUG.Println(NET, "ack watchdog stopping")
+			c.logger.Debug("ack watchdog stopping", componentAttr(NET))
+			return
+		case <-ticker.C:
+			fastReconnectTimeVal := c.fastReconnectCheckStartTime.Load().(time.Time)
+			lastReceivedTimeVal := c.lastReceived.Load().(time.Time)
+
+			if fastReconnectTimeVal.After(lastReceivedTimeVal) {
+				if time.Since(fastReconnectTimeVal) >= ackTimeout {
+					DEBUG.Println(NET, "ack watchdog timeout detected")
+					c.logger.Debug("ack watchdog timeout detected", componentAttr(NET))
+					c.internalConnLost(errors.New("ack watchdog timeout detected"))
+					return
+				}
+			}
+		}
+	}
+}

--- a/watchdog.go
+++ b/watchdog.go
@@ -28,8 +28,8 @@ func ackWatchdog(c *client, ackTimeout time.Duration) {
 
 			if fastReconnectTimeVal.After(lastReceivedTimeVal) {
 				if time.Since(fastReconnectTimeVal) >= ackTimeout {
-					DEBUG.Println(NET, "ack watchdog timeout detected")
-					c.logger.Debug("ack watchdog timeout detected", componentAttr(NET))
+					ERROR.Println(NET, "ack watchdog timeout detected")
+					c.logger.Error("ack watchdog timeout detected", componentAttr(NET))
 					c.internalConnLost(errors.New("ack watchdog timeout detected"))
 					return
 				}

--- a/watchdog_test.go
+++ b/watchdog_test.go
@@ -1,0 +1,486 @@
+package mqtt
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eclipse/paho.mqtt.golang/packets"
+)
+
+type mockBrokerConn struct {
+	net.Conn
+	clientConn   net.Conn
+	brokerConn   net.Conn
+	packetsSent  []packets.ControlPacket
+	packetsRecvd []packets.ControlPacket
+	mu           sync.Mutex
+	paused       bool
+	stopped      bool
+}
+
+func newMockBrokerConn() *mockBrokerConn {
+	clientConn, brokerConn := net.Pipe()
+	return &mockBrokerConn{
+		Conn:         clientConn,
+		clientConn:   clientConn,
+		brokerConn:   brokerConn,
+		packetsSent:  make([]packets.ControlPacket, 0),
+		packetsRecvd: make([]packets.ControlPacket, 0),
+	}
+}
+
+func (m *mockBrokerConn) runBroker() {
+	go func() {
+		defer m.brokerConn.Close()
+
+		for {
+			if m.stopped {
+				return
+			}
+			packet, err := packets.ReadPacket(m.brokerConn)
+			if err != nil {
+				if !m.stopped {
+					ERROR.Println(NET, "Mock broker read error:", err)
+				}
+				return
+			}
+
+			m.mu.Lock()
+			m.packetsRecvd = append(m.packetsRecvd, packet)
+			paused := m.paused
+			m.mu.Unlock()
+
+			DEBUG.Println(NET, "Mock broker received packet:", packet.String())
+
+			if !paused {
+				m.handlePacket(packet)
+			}
+		}
+	}()
+}
+
+func (m *mockBrokerConn) handlePacket(packet packets.ControlPacket) {
+	switch p := packet.(type) {
+	case *packets.ConnectPacket:
+		connack := packets.NewControlPacket(packets.Connack).(*packets.ConnackPacket)
+		connack.ReturnCode = packets.Accepted
+		connack.SessionPresent = false
+		m.sendPacket(connack)
+
+	case *packets.PublishPacket:
+		switch p.Qos {
+		case 1:
+			puback := packets.NewControlPacket(packets.Puback).(*packets.PubackPacket)
+			puback.MessageID = p.MessageID
+			m.sendPacket(puback)
+		case 2:
+			pubrec := packets.NewControlPacket(packets.Pubrec).(*packets.PubrecPacket)
+			pubrec.MessageID = p.MessageID
+			m.sendPacket(pubrec)
+		}
+
+	case *packets.PubrelPacket:
+		pubcomp := packets.NewControlPacket(packets.Pubcomp).(*packets.PubcompPacket)
+		pubcomp.MessageID = p.MessageID
+		m.sendPacket(pubcomp)
+
+	case *packets.SubscribePacket:
+		suback := packets.NewControlPacket(packets.Suback).(*packets.SubackPacket)
+		suback.MessageID = p.MessageID
+		suback.ReturnCodes = make([]byte, len(p.Topics))
+		for i := range p.Topics {
+			suback.ReturnCodes[i] = p.Qoss[i]
+		}
+		m.sendPacket(suback)
+
+	case *packets.UnsubscribePacket:
+		unsuback := packets.NewControlPacket(packets.Unsuback).(*packets.UnsubackPacket)
+		unsuback.MessageID = p.MessageID
+		m.sendPacket(unsuback)
+
+	case *packets.PingreqPacket:
+		pingresp := packets.NewControlPacket(packets.Pingresp).(*packets.PingrespPacket)
+		m.sendPacket(pingresp)
+
+	case *packets.DisconnectPacket:
+		m.stopped = true
+		return
+	}
+}
+
+func (m *mockBrokerConn) sendPacket(packet packets.ControlPacket) {
+	DEBUG.Println(NET, "Mock broker sending packet:", packet.String())
+	err := packet.Write(m.brokerConn)
+	if err != nil {
+		ERROR.Println(NET, "Mock broker send error:", err)
+		return
+	}
+
+	m.mu.Lock()
+	m.packetsSent = append(m.packetsSent, packet)
+	m.mu.Unlock()
+}
+
+func (m *mockBrokerConn) pauseResponses() {
+	m.mu.Lock()
+	m.paused = true
+	m.mu.Unlock()
+	DEBUG.Println(NET, "Mock broker responses paused")
+}
+
+func (m *mockBrokerConn) stop() {
+	m.stopped = true
+	m.clientConn.Close()
+	m.brokerConn.Close()
+}
+
+func (m *mockBrokerConn) getReceivedPackets() []packets.ControlPacket {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]packets.ControlPacket, len(m.packetsRecvd))
+	copy(result, m.packetsRecvd)
+	return result
+}
+
+func createNewClientAndBroker(ackTimeout time.Duration, connectionLostChan chan bool) (Client, *mockBrokerConn) {
+	mockBroker := newMockBrokerConn()
+	mockBroker.runBroker()
+
+	customConnFunc := func(uri *url.URL, options ClientOptions) (net.Conn, error) {
+		return mockBroker.Conn, nil
+	}
+
+	opts := NewClientOptions().
+		SetClientID("test-watchdog-client").
+		SetCustomOpenConnectionFn(customConnFunc).
+		SetAckTimeout(ackTimeout).
+		SetKeepAlive(4 * time.Second).
+		SetAutoReconnect(false).
+		SetConnectionLostHandler(func(c Client, err error) {
+			select {
+			case connectionLostChan <- true:
+			default:
+			}
+		}).
+		AddBroker("tcp://mock-broker:1883")
+
+	client := NewClient(opts)
+	return client, mockBroker
+}
+
+func TestAckWatchdogPublishQoS1Timeout(t *testing.T) {
+	ackTimeout := 1000 * time.Millisecond
+	connectionLost := make(chan bool, 1)
+	client, mockBroker := createNewClientAndBroker(ackTimeout, connectionLost)
+	defer mockBroker.stop()
+
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect: %v", token.Error())
+	}
+
+	mockBroker.pauseResponses()
+
+	pubToken := client.Publish("test/topic", 1, false, "test message")
+
+	select {
+	case <-connectionLost:
+	case <-time.After(ackTimeout + 200*time.Millisecond):
+		t.Fatal("Ack watchdog should have triggered within timeout period")
+	}
+
+	receivedPackets := mockBroker.getReceivedPackets()
+	if len(receivedPackets) < 2 {
+		t.Fatalf("Expected at least 2 packets (CONNECT, PUBLISH), got %d", len(receivedPackets))
+	}
+
+	foundPublish := false
+	for _, packet := range receivedPackets {
+		if _, ok := packet.(*packets.PublishPacket); ok {
+			foundPublish = true
+			break
+		}
+	}
+	if !foundPublish {
+		t.Fatal("PUBLISH packet not found in received packets")
+	}
+
+	if !pubToken.WaitTimeout(100 * time.Millisecond) {
+		t.Fatal("Publish token should complete (with error) after connection loss")
+	}
+
+	client.Disconnect(250)
+}
+
+func TestAckWatchdogPublishQoS2Timeout(t *testing.T) {
+	ackTimeout := 500 * time.Millisecond
+	connectionLost := make(chan bool, 1)
+	client, mockBroker := createNewClientAndBroker(ackTimeout, connectionLost)
+	defer mockBroker.stop()
+
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect: %v", token.Error())
+	}
+
+	mockBroker.pauseResponses()
+
+	pubToken := client.Publish("test/topic", 2, false, "test message qos2")
+
+	select {
+	case <-connectionLost:
+	case <-time.After(ackTimeout + 200*time.Millisecond):
+		t.Fatal("Ack watchdog should have triggered within timeout period")
+	}
+
+	receivedPackets := mockBroker.getReceivedPackets()
+	foundPublish := false
+	for _, packet := range receivedPackets {
+		if pub, ok := packet.(*packets.PublishPacket); ok && pub.Qos == 2 {
+			foundPublish = true
+			break
+		}
+	}
+	if !foundPublish {
+		t.Fatal("QoS 2 PUBLISH packet not found in received packets")
+	}
+
+	if !pubToken.WaitTimeout(100 * time.Millisecond) {
+		t.Fatal("Publish token should complete (with error) after connection loss")
+	}
+
+	client.Disconnect(250)
+}
+
+func TestAckWatchdogSubscribeTimeout(t *testing.T) {
+	ackTimeout := 500 * time.Millisecond
+	connectionLost := make(chan bool, 1)
+	client, mockBroker := createNewClientAndBroker(ackTimeout, connectionLost)
+	defer mockBroker.stop()
+
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect: %v", token.Error())
+	}
+
+	mockBroker.pauseResponses()
+
+	subToken := client.Subscribe("test/topic", 1, nil)
+
+	select {
+	case <-connectionLost:
+	case <-time.After(ackTimeout + 200*time.Millisecond):
+		t.Fatal("Ack watchdog should have triggered within timeout period")
+	}
+
+	receivedPackets := mockBroker.getReceivedPackets()
+	foundSubscribe := false
+	for _, packet := range receivedPackets {
+		if _, ok := packet.(*packets.SubscribePacket); ok {
+			foundSubscribe = true
+			break
+		}
+	}
+	if !foundSubscribe {
+		t.Fatal("SUBSCRIBE packet not found in received packets")
+	}
+
+	if !subToken.WaitTimeout(100 * time.Millisecond) {
+		t.Fatal("Subscribe token should complete (with error) after connection loss")
+	}
+
+	client.Disconnect(250)
+}
+
+func TestAckWatchdogUnsubscribeTimeout(t *testing.T) {
+	ackTimeout := 500 * time.Millisecond
+	connectionLost := make(chan bool, 1)
+	client, mockBroker := createNewClientAndBroker(ackTimeout, connectionLost)
+	defer mockBroker.stop()
+
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect: %v", token.Error())
+	}
+
+	if token := client.Subscribe("test/topic", 1, nil); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to subscribe: %v", token.Error())
+	}
+
+	mockBroker.pauseResponses()
+
+	unsubToken := client.Unsubscribe("test/topic")
+
+	select {
+	case <-connectionLost:
+	case <-time.After(ackTimeout + 200*time.Millisecond):
+		t.Fatal("Ack watchdog should have triggered within timeout period")
+	}
+
+	receivedPackets := mockBroker.getReceivedPackets()
+	foundUnsubscribe := false
+	for _, packet := range receivedPackets {
+		if _, ok := packet.(*packets.UnsubscribePacket); ok {
+			foundUnsubscribe = true
+			break
+		}
+	}
+	if !foundUnsubscribe {
+		t.Fatal("UNSUBSCRIBE packet not found in received packets")
+	}
+
+	if !unsubToken.WaitTimeout(100 * time.Millisecond) {
+		t.Fatal("Unsubscribe token should complete (with error) after connection loss")
+	}
+
+	client.Disconnect(250)
+}
+
+func TestAckWatchdogPingTimeout(t *testing.T) {
+	connectionLost := make(chan bool, 1)
+	mockBroker := newMockBrokerConn()
+	mockBroker.runBroker()
+	defer mockBroker.stop()
+
+	customConnFunc := func(uri *url.URL, options ClientOptions) (net.Conn, error) {
+		return mockBroker.Conn, nil
+	}
+
+	opts := NewClientOptions().
+		SetClientID("test-ping-timeout").
+		SetCustomOpenConnectionFn(customConnFunc).
+		SetKeepAlive(1 * time.Second).
+		SetAckTimeout(500 * time.Millisecond).
+		SetPingTimeout(4 * time.Second).
+		SetAutoReconnect(false).
+		SetConnectionLostHandler(func(c Client, err error) {
+			select {
+			case connectionLost <- true:
+			default:
+			}
+		}).
+		AddBroker("tcp://mock-broker:1883")
+
+	client := NewClient(opts)
+
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect: %v", token.Error())
+	}
+
+	mockBroker.pauseResponses()
+
+	timeout := 2 * time.Second
+
+	select {
+	case <-connectionLost:
+	case <-time.After(timeout):
+		t.Fatal("Ping timeout should have triggered within timeout period")
+	}
+
+	receivedPackets := mockBroker.getReceivedPackets()
+	foundPing := false
+	for _, packet := range receivedPackets {
+		if _, ok := packet.(*packets.PingreqPacket); ok {
+			foundPing = true
+			break
+		}
+	}
+	if !foundPing {
+		t.Fatal("PINGREQ packet not found in received packets")
+	}
+
+	client.Disconnect(250)
+}
+
+func TestAckWatchdogNormalFlow(t *testing.T) {
+	ackTimeout := 500 * time.Millisecond
+	connectionLost := make(chan bool, 1)
+	_, mockBroker := createNewClientAndBroker(ackTimeout, connectionLost)
+	defer mockBroker.stop()
+
+	opts := NewClientOptions().
+		SetClientID("test-watchdog-client").
+		SetCustomOpenConnectionFn(func(uri *url.URL, options ClientOptions) (net.Conn, error) {
+			return mockBroker.Conn, nil
+		}).
+		SetAckTimeout(ackTimeout).
+		SetAutoReconnect(false).
+		SetConnectionLostHandler(func(c Client, err error) {
+			t.Errorf("Unexpected connection lost: %v", err)
+			select {
+			case connectionLost <- true:
+			default:
+			}
+		}).
+		AddBroker("tcp://mock-broker:1883")
+
+	client := NewClient(opts)
+
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect: %v", token.Error())
+	}
+
+	for i := 0; i < 3; i++ {
+		if token := client.Publish(fmt.Sprintf("test/topic/%d", i), 1, false, "test message"); token.Wait() && token.Error() != nil {
+			t.Fatalf("Failed to publish: %v", token.Error())
+		}
+
+		if token := client.Subscribe(fmt.Sprintf("test/sub/%d", i), 1, nil); token.Wait() && token.Error() != nil {
+			t.Fatalf("Failed to subscribe: %v", token.Error())
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	select {
+	case <-connectionLost:
+		t.Fatal("Ack watchdog should not have triggered when responses are received")
+	case <-time.After(ackTimeout + 200*time.Millisecond):
+	}
+
+	client.Disconnect(250)
+}
+
+func TestAckWatchdogDisabled(t *testing.T) {
+	connectionLost := make(chan bool, 1)
+	_, mockBroker := createNewClientAndBroker(0, connectionLost)
+	defer mockBroker.stop()
+
+	opts := NewClientOptions().
+		SetClientID("test-watchdog-client").
+		SetCustomOpenConnectionFn(func(uri *url.URL, options ClientOptions) (net.Conn, error) {
+			return mockBroker.Conn, nil
+		}).
+		SetAckTimeout(0).
+		SetAutoReconnect(false).
+		SetConnectionLostHandler(func(c Client, err error) {
+			t.Errorf("Unexpected connection lost: %v", err)
+			select {
+			case connectionLost <- true:
+			default:
+			}
+		}).
+		AddBroker("tcp://mock-broker:1883")
+
+	client := NewClient(opts)
+
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect: %v", token.Error())
+	}
+
+	mockBroker.pauseResponses()
+
+	pubToken := client.Publish("test/topic", 1, false, "test message")
+
+	select {
+	case <-connectionLost:
+		t.Fatal("Ack watchdog should not trigger when disabled, AckTimeout = 0")
+	case <-time.After(1 * time.Second):
+	}
+
+	if pubToken.WaitTimeout(50 * time.Millisecond) {
+		t.Fatal("Publish token should still be waiting since broker is paused")
+	}
+
+	client.Disconnect(250)
+}


### PR DESCRIPTION
1. This triggered when:

- Publish QoS > 0 
- PINGREQ (Keepalive) 
- Subscribe 
- Unsubscribe 
- PUBREL 

2. Add new option `SetAckTimeout` to set timeout duration for waiting response from broker